### PR TITLE
Handle new dependency automatically

### DIFF
--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,6 +1,0 @@
-{
-  "predef": [
-    "console"
-  ],
-  "strict": false
-}

--- a/blueprints/liquid-fire/index.js
+++ b/blueprints/liquid-fire/index.js
@@ -1,7 +1,0 @@
-module.exports = {
-  description: 'liquid-fire',
-
-  afterInstall: function(options) {
-    return this.addBowerPackageToProject('matchMedia');
-  }
-};

--- a/bower.json
+++ b/bower.json
@@ -10,8 +10,7 @@
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.15",
     "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1",
-    "matchMedia": "~0.2.0"
+    "qunit": "~1.17.1"
   },
   "devDependencies": {
     "bootstrap-sass-official": "~3.3.1",

--- a/index.js
+++ b/index.js
@@ -19,14 +19,18 @@ module.exports = {
       srcDir: '/',
       destDir: 'velocity'
     });
-    return mergeTrees([tree, velocityTree]);
+    var matchMediaPath = path.dirname(require.resolve('match-media'));
+    var matchMediaTree = pickFiles(this.treeGenerator(matchMediaPath), {
+      srcDir: '/',
+      destDir: 'match-media'
+    });
+    return mergeTrees([tree, velocityTree, matchMediaTree]);
   },
 
   included: function(app){
     app.import('vendor/velocity/velocity.js');
     app.import('vendor/liquid-fire.css');
-    // Polyfill for matchMedia
-    app.import(app.bowerDirectory+'/matchMedia/matchMedia.js');
+    app.import('vendor/match-media/matchMedia.js');
   },
 
   setupPreprocessorRegistry: function(type, registry) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ember-giftwrap": "0.0.2",
     "git-repo-info": "^1.0.4",
     "github": "git://github.com/mikedeboer/node-github#ca90bf27d5820812c3b76908189d666446ed97cd",
+    "match-media": "^0.2.0",
     "ncp": "^2.0.0",
     "rsvp": "^3.0.17",
     "ember-try": "0.0.6"


### PR DESCRIPTION
Using bower here creates an upgrade hazard. This change
switches us to load the polyfill automatically via npm instead. This is
easier for users to get right without doing anything special.

The downside is that users who already happen to have the same lib in
their bower deps will get a second copy. Proper dependency flattening of
npm packages in on ember-cli's roadmap.
